### PR TITLE
v0.4.1

### DIFF
--- a/Cargo-linux.lock
+++ b/Cargo-linux.lock
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "pywry"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures-util",
  "image",

--- a/Cargo-linux.toml
+++ b/Cargo-linux.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pywry"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 include = ["src/", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "pywry"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures-util",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pywry"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 include = ["src/", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pywry"
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",

--- a/python/pywry/core.py
+++ b/python/pywry/core.py
@@ -18,6 +18,14 @@ from websockets.exceptions import ConnectionClosedError
 from pywry import pywry
 
 __all__ = ["PyWry", "BackendFailedToStart"]
+Websocket_Error = (
+    TimeoutError,
+    OSError,
+    CancelledError,
+    socket.gaierror,
+    ConnectionClosedError,
+    IncompleteReadError,
+)
 
 
 class BackendFailedToStart(Exception):
@@ -91,7 +99,7 @@ class PyWry:
             try:
                 if await self.send_test(host, port):
                     return host
-            except (TimeoutError, OSError, CancelledError, IncompleteReadError):
+            except Websocket_Error:
                 pass
 
     def send_html(self, html_str: str = "", html_path: str = "", title: str = ""):
@@ -150,7 +158,7 @@ class PyWry:
                     if response == "SUCCESS":
                         return True
                     return False
-                except (ConnectionClosedError, OSError, IncompleteReadError):
+                except Websocket_Error:
                     return False
 
     def get_clean_port(self) -> str:

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,7 +1,5 @@
-use image::ImageFormat;
 use serde_json::Value;
-use std::fs::{read, read_to_string};
-use wry::application::window::Icon;
+use std::fs::read_to_string;
 
 pub struct Showable {
     pub html_path: String,
@@ -9,7 +7,7 @@ pub struct Showable {
     pub title: String,
     pub height: Option<u32>,
     pub width: Option<u32>,
-    pub icon: Option<Icon>,
+    pub icon: String,
     pub figure: Option<Value>,
     pub data: Option<Value>,
     pub download_path: String,
@@ -55,33 +53,13 @@ impl Showable {
             html_path = read_to_string(html_path).unwrap_or_default();
         }
 
-        let icon_object = match read(icon) {
-            Err(_) => None,
-            Ok(bytes) => {
-                let imagebuffer =
-                    match image::load_from_memory_with_format(&bytes, ImageFormat::Png) {
-                        Err(_) => None,
-                        Ok(loaded) => {
-                            let imagebuffer = loaded.to_rgba8();
-                            let (icon_width, icon_height) = imagebuffer.dimensions();
-                            let icon_rgba = imagebuffer.into_raw();
-                            match Icon::from_rgba(icon_rgba, icon_width, icon_height) {
-                                Err(_) => None,
-                                Ok(icon) => Some(icon),
-                            }
-                        }
-                    };
-                imagebuffer
-            }
-        };
-
         Some(Self {
             html_path,
             html_str,
             title,
             height,
             width,
-            icon: icon_object,
+            icon,
             figure,
             data,
             download_path,
@@ -99,7 +77,7 @@ impl Default for Showable {
             title: "Error Creating Showable Object".to_string(),
             height: None,
             width: None,
-            icon: None,
+            icon: "".to_string(),
             figure: None,
             data: None,
             download_path: "".to_string(),


### PR DESCRIPTION
- implement new window request handler to fix mac/linux `_blank` links not working
- replace `println!("\nFile saved {:?}", filepath);`  with  `println!("File saved\n");` for mac download success confirmation 
- catch `socket.gaierror` in `get_valid_host()`
