### PR TITLE
v0.4.5

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   manylinux_2_28:
-    name: Build nightly only
+    name: Build manylinux_2_28 wheels
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Cargo-linux.lock
+++ b/Cargo-linux.lock
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "pywry"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "futures-util",
  "image",

--- a/Cargo-linux.toml
+++ b/Cargo-linux.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pywry"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 include = ["src/", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "pywry"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "futures-util",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pywry"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 include = ["src/", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pywry"
-version = "0.4.4"
+version = "0.4.5"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",

--- a/python/pywry/core.py
+++ b/python/pywry/core.py
@@ -92,8 +92,11 @@ class PyWry:
             "0.0.0.0",
             "host.docker.internal",
             "localhost",
-            socket.gethostbyname(socket.gethostname()),
         ]
+        try:
+            try_hosts.append(socket.gethostbyname(socket.gethostname()))
+        except socket.gaierror:
+            pass
 
         for host in try_hosts:
             try:


### PR DESCRIPTION
- fix runtime error if no `socket.gethostbyname(socket.gethostname())` (running in a VM)