### PR TITLE
v0.5.3

### DIFF
--- a/Cargo-linux.lock
+++ b/Cargo-linux.lock
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "pywry"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "image",
  "mime_guess",

--- a/Cargo-linux.toml
+++ b/Cargo-linux.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pywry"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 include = ["src/", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "pywry"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "image",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pywry"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 include = ["src/", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/examples/plotly_figure/poetry.lock
+++ b/examples/plotly_figure/poetry.lock
@@ -68,25 +68,25 @@ tenacity = ">=6.2.0"
 
 [[package]]
 name = "pywry"
-version = "0.5.2"
+version = "0.5.3"
 description = ""
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pywry-0.5.2-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:68e23f974db0a31e340016300f895bc00cd44fa1194208ddc1820cd23c98ba92"},
-    {file = "pywry-0.5.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4b43dc407bd87266a71edf79a568df58291513b78da6cfd0e2a2b4268ccf862f"},
-    {file = "pywry-0.5.2-cp310-none-win_amd64.whl", hash = "sha256:957274a1603558a38576e2d04a0db142fb4c7e053c20e5770e5552124d9de906"},
-    {file = "pywry-0.5.2-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:e38c11a932f5844c5130a42dd20599c8e608a87bce9499962d454a6f6aa1e35c"},
-    {file = "pywry-0.5.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0d310e0c5f415752f19aaf8827c214b34133aa8a4c57509ea1dde12ac0c2cffb"},
-    {file = "pywry-0.5.2-cp311-none-win_amd64.whl", hash = "sha256:695b7776e3e1a976578519ea2914e9ae17a72023fe0f6dd49cd680e71bc4bb50"},
-    {file = "pywry-0.5.2-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:00a23256553a3badbdc7c028171f9659341cda5dd3e39d4a29fc093caa13a76d"},
-    {file = "pywry-0.5.2-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:7601fedb7dc709a72d3dba975dde871a37445678f738d491ee5d09dc395f8625"},
-    {file = "pywry-0.5.2-cp38-none-win_amd64.whl", hash = "sha256:f6a85cbaffbdcbb9ca5c6421c5ed104a7c0a5a59abd3ad11c00f01112036e508"},
-    {file = "pywry-0.5.2-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:da4ca7ad6a9c8e05176952d287b847dcd3b171fd292a8af088554b43c2321c9b"},
-    {file = "pywry-0.5.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:a02a1d5b4a7ec2833ce0055d93e7efbb0bc8528abf66f819150af20f3cd252e3"},
-    {file = "pywry-0.5.2-cp39-none-win_amd64.whl", hash = "sha256:2d8b6488f318101c5c33f7c6abaed34fdc3ad0ae11996e3e933f8c51b4ffccf4"},
-    {file = "pywry-0.5.2.tar.gz", hash = "sha256:f23131d5347513aa231a03d1f972704f772d7b1175e38c95668599f560989939"},
+    {file = "pywry-0.5.3-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b39f188a4cec454729ccda9e854a0ad58eedd9bb102ecb01f8fdc08280d44347"},
+    {file = "pywry-0.5.3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e770ed965ad38a8aa3656740731ebaaed056c4bdef7c3487434e59b24df61d63"},
+    {file = "pywry-0.5.3-cp310-none-win_amd64.whl", hash = "sha256:02c27c2be136a7301a930f53daf797944443d2a35aca37040616c9868920a8e0"},
+    {file = "pywry-0.5.3-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:778252bf9281773e209284c3a34b18422e1f0921a8af57a52c6a493dfe050434"},
+    {file = "pywry-0.5.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:736f01abc8f142868b1d8b28d505f972e4c54aea313599151eadd58985a9da56"},
+    {file = "pywry-0.5.3-cp311-none-win_amd64.whl", hash = "sha256:254d2222d23d26b68b642c138d64d438b744650a0b39e6672e15b8f031623847"},
+    {file = "pywry-0.5.3-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:66be5f3db5eca461ba6704404650d97856670ba678fed716dac52709679eb34e"},
+    {file = "pywry-0.5.3-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:3cb6d72dc60d44a0d2d5a7249751381095ea85a40fa67b90c4755f0a049fdff0"},
+    {file = "pywry-0.5.3-cp38-none-win_amd64.whl", hash = "sha256:b380878138fe68ab0b699a5593edd879516a63d457da1ccc72a76297551dc52f"},
+    {file = "pywry-0.5.3-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:ee0cf8e355c93da194af734ad164bc28208d5dc15cdc3150b1abe6c5fd46ba92"},
+    {file = "pywry-0.5.3-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:2f0b9e477e9615e68dab7906f6ed6f44e0901f61c8d2d36d3d5688e54a622b2e"},
+    {file = "pywry-0.5.3-cp39-none-win_amd64.whl", hash = "sha256:5d0a7f6bbc054ad6afc5bc84a388d45b4fdd9d429c96c32c936b47cc260cbdd9"},
+    {file = "pywry-0.5.3.tar.gz", hash = "sha256:8ae6593a1c2cc5c7a747cc8b0af37663f178a596ec17fc7d5c6d8e26b679009a"},
 ]
 
 [package.dependencies]
@@ -198,4 +198,4 @@ doc = ["reno", "sphinx", "tornado (>=4.5)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "892af0cdece5ebde52d6eae9e18ec564ca20aad39b6e8b69b08890d0a985b8e9"
+content-hash = "1f8cbe4986b0bd480a91a1a8c49802bec16090548c9302596312410f99681582"

--- a/examples/plotly_figure/pyproject.toml
+++ b/examples/plotly_figure/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "pywry_plotly_demo", from = "." }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pywry = "^0.5.2"
+pywry = "^0.5.3"
 plotly = "^5.3.1"
 numpy = "^1.21.1"
 

--- a/examples/streamlit/poetry.lock
+++ b/examples/streamlit/poetry.lock
@@ -68,14 +68,14 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
 ]
 
 [[package]]
@@ -807,25 +807,25 @@ tzdata = {version = "*", markers = "python_version >= \"3.6\""}
 
 [[package]]
 name = "pywry"
-version = "0.5.2"
+version = "0.5.3"
 description = ""
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pywry-0.5.2-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:68e23f974db0a31e340016300f895bc00cd44fa1194208ddc1820cd23c98ba92"},
-    {file = "pywry-0.5.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4b43dc407bd87266a71edf79a568df58291513b78da6cfd0e2a2b4268ccf862f"},
-    {file = "pywry-0.5.2-cp310-none-win_amd64.whl", hash = "sha256:957274a1603558a38576e2d04a0db142fb4c7e053c20e5770e5552124d9de906"},
-    {file = "pywry-0.5.2-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:e38c11a932f5844c5130a42dd20599c8e608a87bce9499962d454a6f6aa1e35c"},
-    {file = "pywry-0.5.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0d310e0c5f415752f19aaf8827c214b34133aa8a4c57509ea1dde12ac0c2cffb"},
-    {file = "pywry-0.5.2-cp311-none-win_amd64.whl", hash = "sha256:695b7776e3e1a976578519ea2914e9ae17a72023fe0f6dd49cd680e71bc4bb50"},
-    {file = "pywry-0.5.2-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:00a23256553a3badbdc7c028171f9659341cda5dd3e39d4a29fc093caa13a76d"},
-    {file = "pywry-0.5.2-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:7601fedb7dc709a72d3dba975dde871a37445678f738d491ee5d09dc395f8625"},
-    {file = "pywry-0.5.2-cp38-none-win_amd64.whl", hash = "sha256:f6a85cbaffbdcbb9ca5c6421c5ed104a7c0a5a59abd3ad11c00f01112036e508"},
-    {file = "pywry-0.5.2-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:da4ca7ad6a9c8e05176952d287b847dcd3b171fd292a8af088554b43c2321c9b"},
-    {file = "pywry-0.5.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:a02a1d5b4a7ec2833ce0055d93e7efbb0bc8528abf66f819150af20f3cd252e3"},
-    {file = "pywry-0.5.2-cp39-none-win_amd64.whl", hash = "sha256:2d8b6488f318101c5c33f7c6abaed34fdc3ad0ae11996e3e933f8c51b4ffccf4"},
-    {file = "pywry-0.5.2.tar.gz", hash = "sha256:f23131d5347513aa231a03d1f972704f772d7b1175e38c95668599f560989939"},
+    {file = "pywry-0.5.3-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b39f188a4cec454729ccda9e854a0ad58eedd9bb102ecb01f8fdc08280d44347"},
+    {file = "pywry-0.5.3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e770ed965ad38a8aa3656740731ebaaed056c4bdef7c3487434e59b24df61d63"},
+    {file = "pywry-0.5.3-cp310-none-win_amd64.whl", hash = "sha256:02c27c2be136a7301a930f53daf797944443d2a35aca37040616c9868920a8e0"},
+    {file = "pywry-0.5.3-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:778252bf9281773e209284c3a34b18422e1f0921a8af57a52c6a493dfe050434"},
+    {file = "pywry-0.5.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:736f01abc8f142868b1d8b28d505f972e4c54aea313599151eadd58985a9da56"},
+    {file = "pywry-0.5.3-cp311-none-win_amd64.whl", hash = "sha256:254d2222d23d26b68b642c138d64d438b744650a0b39e6672e15b8f031623847"},
+    {file = "pywry-0.5.3-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:66be5f3db5eca461ba6704404650d97856670ba678fed716dac52709679eb34e"},
+    {file = "pywry-0.5.3-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:3cb6d72dc60d44a0d2d5a7249751381095ea85a40fa67b90c4755f0a049fdff0"},
+    {file = "pywry-0.5.3-cp38-none-win_amd64.whl", hash = "sha256:b380878138fe68ab0b699a5593edd879516a63d457da1ccc72a76297551dc52f"},
+    {file = "pywry-0.5.3-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:ee0cf8e355c93da194af734ad164bc28208d5dc15cdc3150b1abe6c5fd46ba92"},
+    {file = "pywry-0.5.3-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:2f0b9e477e9615e68dab7906f6ed6f44e0901f61c8d2d36d3d5688e54a622b2e"},
+    {file = "pywry-0.5.3-cp39-none-win_amd64.whl", hash = "sha256:5d0a7f6bbc054ad6afc5bc84a388d45b4fdd9d429c96c32c936b47cc260cbdd9"},
+    {file = "pywry-0.5.3.tar.gz", hash = "sha256:8ae6593a1c2cc5c7a747cc8b0af37663f178a596ec17fc7d5c6d8e26b679009a"},
 ]
 
 [package.dependencies]
@@ -836,21 +836,21 @@ dev = ["auditwheel", "wheel"]
 
 [[package]]
 name = "requests"
-version = "2.29.0"
+version = "2.30.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "requests-2.29.0-py3-none-any.whl", hash = "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b"},
-    {file = "requests-2.29.0.tar.gz", hash = "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"},
+    {file = "requests-2.30.0-py3-none-any.whl", hash = "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294"},
+    {file = "requests-2.30.0.tar.gz", hash = "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
 charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
@@ -1130,20 +1130,21 @@ devenv = ["black", "check-manifest", "flake8", "pyroma", "pytest (>=4.3)", "pyte
 
 [[package]]
 name = "urllib3"
-version = "1.26.15"
+version = "2.0.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7"
 files = [
-    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
-    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
+    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
+    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "validators"
@@ -1221,4 +1222,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.8"
-content-hash = "5c2a520fd5765c27e36995f90acc563e378135d8b59ead25b090041b9b43432b"
+content-hash = "acb7d690515210fbbdc13e5816beb9cc8495ba9bc1afce562f1d83c55060ffc2"

--- a/examples/streamlit/pyproject.toml
+++ b/examples/streamlit/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{ include = "pywry_streamlit_demo", from = "." }]
 [tool.poetry.dependencies]
 python = "^3.9.8"
 streamlit = "^1.21.0"
-pywry = "^0.5.2"
+pywry = "^0.5.3"
 pandas = "^2.0.1"
 numpy = "^1.21.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pywry"
-version = "0.5.2"
+version = "0.5.3"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",

--- a/python/pywry/core.py
+++ b/python/pywry/core.py
@@ -27,14 +27,14 @@ AsyncioException = (
 
 ACCEPTED_KEYS_TYPES = {
     "html_str": str,
-    "html_path": Union[str, Path],
+    "html_path": (str, Path),
     "title": str,
-    "icon": Union[str, Path],
-    "json_data": Union[dict, str],
+    "icon": (str, Path),
+    "json_data": (dict, str),
     "height": int,
     "width": int,
-    "download_path": Union[str, Path],
-    "export_image": Union[str, Path],
+    "download_path": (str, Path),
+    "export_image": (str, Path),
 }
 
 
@@ -180,9 +180,9 @@ class PyWry:
                         f"Expected {ACCEPTED_KEYS_TYPES[key]}, got {type(value)}"
                     )
                 if isinstance(value, Path):
-                    if not value.exists():
+                    if value.is_file() and not value.exists() and key != "export_image":
                         raise FileNotFoundError(value)
-                    value = value.resolve().as_posix()
+                    value = str(value.resolve())
             except Exception:
                 self.print_debug()
                 continue


### PR DESCRIPTION
- fix ACCEPTED_KEYS_TYPES failing on checks in python3.9 (doesn't like isinstance on `Union`'s)